### PR TITLE
fix: can't login if behind a proxy and using HTTPS

### DIFF
--- a/modules/server.ts
+++ b/modules/server.ts
@@ -257,7 +257,7 @@ export async function startServer() {
       // strictness means cookie will only be readable with this site specifically
 
       ctx.cookies.set("jwt-access", access.token, {
-        secure: config.https,
+        secure: (config.https && !config.proxy),
         httpOnly: true,
         sameSite: "strict",
         maxAge: access.expiry,

--- a/modules/server.ts
+++ b/modules/server.ts
@@ -131,6 +131,9 @@ export async function startServer() {
   const app = new Koa();
   const router = new Router();
 
+  // trust proxy header fields if proxy enabled.
+  app.proxy = config.proxy;
+
   app.use(restoreRequesterIP);
   app.use(rateLimiter);
   app.use(koaIp({
@@ -257,7 +260,7 @@ export async function startServer() {
       // strictness means cookie will only be readable with this site specifically
 
       ctx.cookies.set("jwt-access", access.token, {
-        secure: (config.https && !config.proxy),
+        secure: config.https,
         httpOnly: true,
         sameSite: "strict",
         maxAge: access.expiry,


### PR DESCRIPTION
This one probably needs a little more explanation.

I've been using Cakelandish behind a reverse proxy - Caddy, specifically. As such, I don't use the built-in certificate features of Cakelandish, but this results in a bit of a catch 22: if I disable HTTPS, the URLs it generates are wrong, but if I enable HTTPS, it thinks I'm sending data insecurely and refuses to accept login tokens.

I figure this is _a_ solution to this catch 22: only set the secure flag if proxy isn't enabled. This does make the assumption that, if someone is using a proxy _and_ enables HTTPS, that they're handling HTTPS on the reverse proxy end.