### PR TITLE
fix: make file extension checks case insensitive

### DIFF
--- a/modules/db.ts
+++ b/modules/db.ts
@@ -470,7 +470,7 @@ export async function applyLayoutToPost(layout, post) {
     new RegExp("%%%media%%%", "g"),
     (post.ogpExtra && post.ogpExtra.mediaData)
       ? post.ogpExtra.mediaData.sort((a, b) => a.order - b.order).map((m) => {
-        const extension = m.absoluteUrl.split(".").reverse()[0];
+        const extension = m.absoluteUrl.split(".").reverse()[0].toLowerCase();
         let output = "";
         if (m.absoluteUrl) {
           if (imageTypes.includes(extension)) {

--- a/static/index.html
+++ b/static/index.html
@@ -386,7 +386,7 @@
               post.ogpExtra.mediaData = post.ogpExtra.mediaData
                 .sort((a, b) => a.order - b.order)
                 .map(media => {
-                  const extension = media.absoluteUrl.split(".").reverse()[0];
+                  const extension = media.absoluteUrl.split(".").reverse()[0].toLowerCase();
                   let mediaType = "";
                   if (imageTypes.includes(extension)) {
                     mediaType = "image";

--- a/static/layout.html
+++ b/static/layout.html
@@ -141,7 +141,7 @@
             this.defaultInjections.ogpExtra.mediaData ? this.defaultInjections.ogpExtra.mediaData
               .sort((a, b) => a.order - b.order)
               .map(m => {
-              const extension = m.absoluteUrl.split(".").reverse()[0];
+              const extension = m.absoluteUrl.split(".").reverse()[0].toLowerCase();
               let output = "";
               if (m.absoluteUrl) {
                 if (imageTypes.includes(extension)) {

--- a/static/upload.html
+++ b/static/upload.html
@@ -395,7 +395,7 @@
               if (!m.embedMedia) {
                 return "";
               }
-              const extension = m.url.split(".").reverse()[0];
+              const extension = m.url.split(".").reverse()[0].toLowerCase();
               let output = "";
               if (m.url) {
                 if (imageTypes.includes(extension)) {
@@ -525,7 +525,7 @@
           let imageTypes = util.imageTypes();
           let audioTypes = util.audioTypes();
           let videoTypes = util.videoTypes();
-          const extension = fileName.split(".").reverse()[0];
+          const extension = fileName.split(".").reverse()[0].toLowerCase();
           const imgInjection = `\n<img src="${fileName}"></img>`;
           const audioInjection = `\n<audio controls>
 <source src="${fileName}">


### PR DESCRIPTION
I was having a weird time with my images sometimes being parsed as links. I was unsure what was causing this, until I realized all the working images had a .png extension and the incorrectly parsed ones had a .PNG extension. I then looked into the code and noticed that it compares the extension against a list of extensions, all in lowercase.

I've went ahead and patched this by forcing the extension value to lowercase before it can run the comparisons.